### PR TITLE
Reduce client-side runtime memory (drop @nuxt/content SQLite-WASM) + fix docs trailing-slash routing

### DIFF
--- a/components/blog/BlogPost.vue
+++ b/components/blog/BlogPost.vue
@@ -211,7 +211,7 @@ const { data: postData } = await useAsyncData(
   () => queryCollection("blog").path(props.routeName).first(),
   {
     getCachedData: (key) =>
-      nuxtApp.isHydrating ? nuxtApp.payload.data[key] : undefined,
+      nuxtApp.payload.data[key] ?? nuxtApp.static.data[key],
   },
 );
 
@@ -240,7 +240,7 @@ const { data: allPosts } = await useAsyncData(
   },
   {
     getCachedData: (key) =>
-      nuxtApp.isHydrating ? nuxtApp.payload.data[key] : undefined,
+      nuxtApp.payload.data[key] ?? nuxtApp.static.data[key],
   },
 );
 

--- a/components/content/ProseA.vue
+++ b/components/content/ProseA.vue
@@ -27,10 +27,19 @@ function processPath(inputPath: string): string {
   const route = useRoute();
   const currentPath = route.path;
 
-  // Add the current path to the processed path
-  const finalPath = joinPath(currentPath, pathWithoutMd);
+  // GitBook "current directory" links that only carry an anchor — "./#foo",
+  // ".#foo", "#foo", "./" — refer to the current page. Resolve them to the
+  // current route plus the hash directly. Passing them through joinPath emits a
+  // "/./" segment that normalizes to a trailing-slash URL (e.g. /docs/ecosystem/),
+  // which isn't prerendered: it 404s on reload and, on SPA nav, re-runs a
+  // client-side content query that boots the SQLite-WASM engine.
+  const samePage = pathWithoutMd.match(/^\.?\/?(#.*)?$/);
+  if (samePage) {
+    return `${currentPath.replace(/\/$/, "")}${samePage[1] ?? ""}`;
+  }
 
-  return finalPath;
+  // Drop a leading "./" so joinPath doesn't leave a "/./" in the result.
+  return joinPath(currentPath, pathWithoutMd.replace(/^\.\//, ""));
 }
 </script>
 

--- a/components/docs/item.vue
+++ b/components/docs/item.vue
@@ -146,14 +146,16 @@ const props = defineProps({
   },
 });
 
-const currentPageExist = await pageExist(props.routeName);
-if (!currentPageExist) {
-  throw createError({ statusCode: 404, statusMessage: "Page not found" });
-}
-
 const { data: doc } = await useAsyncData(`docs-${props.routeName}`, () =>
   queryCollection("docs").path(props.routeName).first(),
 );
+
+// A page "exists" only if it resolves and isn't blacklisted (mirrors
+// `pageExist`, but reuses the payload-cached `doc` query above instead of a
+// second, un-cached lookup that would boot the SQLite-WASM engine client-side).
+if (!doc.value || isPageBlacklisted(props.routeName)) {
+  throw createError({ statusCode: 404, statusMessage: "Page not found" });
+}
 
 // Previous / next page navigation (issue #358). Content v3 returns the
 // surrounding pages in the collection's natural (file) order as [prev, next].
@@ -179,19 +181,24 @@ const nextPage = computed(() => inCurrentCategory(surround.value?.[1]));
 const pagerPath = (path: string) => localePath(path.replace(/\/readme$/, ""));
 
 // All pages within the current category (prefix match on the path).
-const categoryQuery = queryCollection("docs").where(
-  "path",
-  "LIKE",
-  `${props.currentCategory}%`,
+const { data: everything } = await useAsyncData(
+  `docs-category-${props.currentCategory}`,
+  () => {
+    const categoryQuery = queryCollection("docs").where(
+      "path",
+      "LIKE",
+      `${props.currentCategory}%`,
+    );
+    // Changelog entries read newest-first; other categories keep file order.
+    // Ordering stays inside the handler so `filteredList` sees the sorted list.
+    return props.currentCategory === "/docs/changelog"
+      ? categoryQuery.order("title", "DESC").all()
+      : categoryQuery.all();
+  },
 );
-const everythingQuery =
-  props.currentCategory === "/docs/changelog"
-    ? categoryQuery.order("title", "DESC")
-    : categoryQuery;
-
-const everything = ref(await everythingQuery.all());
-const index = ref(
-  await queryCollection("docs").path(`${props.currentCategory}/readme`).first(),
+const { data: index } = await useAsyncData(
+  `docs-index-${props.currentCategory}`,
+  () => queryCollection("docs").path(`${props.currentCategory}/readme`).first(),
 );
 
 const scrollSpy = useScrollSpy();
@@ -206,7 +213,7 @@ const filteredList = computed(() => {
   const seen = new Set<string>();
   // Cast to a shallow shape: the full collection item type is deeply recursive
   // (body AST) and trips TS's "excessively deep" instantiation limit here.
-  const articles = everything.value as Array<{ path?: string }>;
+  const articles = (everything.value ?? []) as Array<{ path?: string }>;
   return articles.filter((article) => {
     if (!article.path) {
       return false;

--- a/components/download/downloader/manager.vue
+++ b/components/download/downloader/manager.vue
@@ -136,6 +136,9 @@ const downloadItem = (
 };
 
 onMounted(() => eventBus.on(UserInteractionEvents.DOWNLOAD_ITEM, downloadItem));
+onUnmounted(() =>
+  eventBus.off(UserInteractionEvents.DOWNLOAD_ITEM, downloadItem),
+);
 
 const removeComponent = (id: string) => {
   const component = components.value.find((item) => item.id === id);

--- a/components/header/logo.vue
+++ b/components/header/logo.vue
@@ -101,9 +101,11 @@ const localePath = useLocalePath();
 const maskCircle = ref<HTMLElement | null>(null);
 const hover = ref(false);
 const animation = ref<gsap.core.Tween | null>(null);
+const revertTimer = ref<ReturnType<typeof setTimeout> | null>(null);
 
 function touchRevertAnimation() {
-  setTimeout(() => {
+  if (revertTimer.value) clearTimeout(revertTimer.value);
+  revertTimer.value = setTimeout(() => {
     hover.value = false;
   }, 1000);
 }
@@ -126,5 +128,10 @@ onMounted(async () => {
     duration: 0.6,
     ease: "linear",
   });
+});
+
+onBeforeUnmount(() => {
+  if (revertTimer.value) clearTimeout(revertTimer.value);
+  animation.value?.kill();
 });
 </script>

--- a/components/index-hero.vue
+++ b/components/index-hero.vue
@@ -231,8 +231,10 @@ const initAnimation = async () => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
             gsap.ticker.add(updateProgress);
+            tlBounce.play();
           } else {
             gsap.ticker.remove(updateProgress);
+            tlBounce.pause();
           }
         });
       });

--- a/components/language-handler.vue
+++ b/components/language-handler.vue
@@ -19,8 +19,13 @@ const changeLanguage = (
   setLocale(event.lang as Parameters<typeof setLocale>[0]);
 };
 
-// Listen for the changeLanguage event
-eventBus.on(UserInteractionEvents.LANGUAGE_CHANGE, changeLanguage);
+// Listen for the changeLanguage event (client-only; register after mount)
+onMounted(() =>
+  eventBus.on(UserInteractionEvents.LANGUAGE_CHANGE, changeLanguage),
+);
+onUnmounted(() =>
+  eventBus.off(UserInteractionEvents.LANGUAGE_CHANGE, changeLanguage),
+);
 
 const onAfterEnter = () => {
   if (languageChanged.value) {

--- a/components/markdown-renderer.vue
+++ b/components/markdown-renderer.vue
@@ -15,24 +15,27 @@ const props = defineProps({
 });
 
 const divRef: Ref<HTMLElement | null> = ref(null);
+const router = useRouter();
+
+const handleLinkClick = (event: MouseEvent) => {
+  const target: HTMLElement | undefined = event.target as HTMLElement;
+  if (target && target.tagName === "A") {
+    const href = target.getAttribute("href");
+    const targetAttr = target.getAttribute("target");
+
+    if (href && href[0] === "/" && targetAttr !== "_blank") {
+      event.preventDefault();
+      router.push(href);
+    }
+  }
+};
 
 onMounted(() => {
-  const el = divRef.value;
-  if (el) {
-    el.addEventListener("click", (event) => {
-      const target: HTMLElement | undefined = event.target as HTMLElement;
-      if (target && target.tagName === "A") {
-        const href = target.getAttribute("href");
-        const targetAttr = target.getAttribute("target");
-        const router = useRouter();
+  divRef.value?.addEventListener("click", handleLinkClick);
+});
 
-        if (href && href[0] === "/" && targetAttr !== "_blank") {
-          event.preventDefault();
-          router.push(href);
-        }
-      }
-    });
-  }
+onBeforeUnmount(() => {
+  divRef.value?.removeEventListener("click", handleLinkClick);
 });
 
 async function renderMarkdown(text: string) {

--- a/content/blog/news/hardfork-six.md
+++ b/content/blog/news/hardfork-six.md
@@ -1,6 +1,6 @@
 ---
 title: "Hard Fork Six"
-description: "Beam completed an emergency hard fork to patch a subtle Bulletproofs rangeproof vulnerability that eluded multiple professional audits and AI reviews. Read the technical breakdown, our risk assessment, and the proposed lustration process for verifying supply integrity."
+description: "Beam has completed a necessary security hard fork to address a subtle Bulletproofs rangeproof vulnerability discovered in the Beam core code. The issue was responsibly disclosed, reviewed by the developers, patched in a non-public branch, and resolved through a coordinated network upgrade. This post explains the technical background, our current risk assessment, and a proposed lustration process that would allow the community to verify supply integrity with a one-time, limited disclosure of legacy outputs."
 date: "2026-07-01"
 category: "news"
 tags:
@@ -10,23 +10,21 @@ tags:
 
 ## Context
 
-The Beam developers were contacted on June 13th 2026 with a report about a possible vulnerability in Beam core code. As the former Beam team still proposes bounties for serious vulnerabilities, many such reports have been received lately, most of them being AI slop without any real interest. However, after careful examination and testing during the next few days, that one report proved to indeed identify a well hidden, but real and important vulnerability.
-
-With the deep analysis done and the problem well identified, the core code was corrected in a non-public branch, and direct contact was made with the main mining pools and exchanges to ask them to upgrade to the new version, so that any further risk of exploitation of this vulnerability would be eliminated. The hard fork took place at block 3928666.
-
+On June 13, 2026, Beam developers were contacted with a report describing a possible vulnerability in Beam core code. After careful review and testing over the following days, the report was confirmed to identify a subtle but real vulnerability.
+Once the issue was understood, the core code was corrected in a non-public branch. The main mining pools and exchanges were then contacted directly and asked to upgrade to the corrected version, eliminating any further risk of exploitation. The hard fork took place at block 3928666.
 The latest corrected builds (wallets, nodes, etc.) can be downloaded from [beam.mw/downloads](https://beam.mw/downloads) or from [github.com/BeamMW/beam/releases](https://github.com/BeamMW/beam/releases) and [github.com/BeamMW/beam-ui/releases](https://github.com/BeamMW/beam-ui/releases).
 
 ## Technical details
 
 The discovered vulnerability was in Beam’s implementation of Bulletproofs, a popular variant of rangeproofs with exponential compression (excellent for scalability). A rangeproof is the zero-knowledge cryptographic scheme which proves that the transaction output (TXO) is a well-formed Pedersen commitment, and holds a non-negative amount.
 
-While the algebra behind Beam’s implementation was correct, there was an error in the transcript, i.e. in the order of challenge-response sequence for the challenges derived via the Fiat-Shamir heuristic. Specifically, the error was in the IPA (inner-product argument) part where the order of challenge-response was inverted: the sequence where the prover gets the challenge and then emits the LR pair should happen the other way around.
+While the algebra behind Beam’s implementation was correct, there was an error in the transcript, i.e. in the order of challenge-response sequence for the challenges derived via the Fiat-Shamir heuristic. Specifically, the error was in the IPA (inner-product argument) part where the order of challenge-response was inverted: the sequence where the prover gets the challenge and then emits the LR pair should happen the other way around. 
 
 In [`ecc_bulletproof.cpp#L453`](https://github.com/BeamMW/beam/blob/ebc40098938197bea689b853a7f51fb507c843d5/core/ecc_bulletproof.cpp#L453), `CycleStart()` is where challenges are obtained.
 
 And [`ecc_bulletproof.cpp#L463`](https://github.com/BeamMW/beam/blob/ebc40098938197bea689b853a7f51fb507c843d5/core/ecc_bulletproof.cpp#L463) is where the extracted LR are exposed.
 
-As a result, after the very last challenge, the prover emits the last LR pair, plus the two "folded" scalars. Meaning that the LR, the EC points (group elements), are not pinned by the challenge, and could thus be modified a-posteriori to satisfy the equation. This is a serious vulnerability, as it could -in theory- be used to forge a TXO that holds a negative amount. This in turn allows to create a balanced transaction where another TXO is minted from thin air with the appropriate positive amount.
+As a result, after the very last challenge, the prover emits the last LR pair, plus the two "folded" scalars. Meaning that the LR, the EC points (group elements), are not pinned by the challenge, and could thus be modified a-posteriori to satisfy the equation. This is a serious vulnerability because, in theory, it could be used to construct a TXO with a negative amount. If successfully exploited, such an output could be used to balance a transaction containing another TXO with a corresponding positive amount, creating a risk of unauthorized supply creation.
 
 This was a very difficult vulnerability to discover, and it is worth noting that before the release of its mainnet in 2019, Beam code underwent security audits by several companies, which did not identify it:
 
@@ -38,7 +36,7 @@ More recently, with the rise of AI, several AI agents were used to scan the Beam
 
 Moreover, after the above vulnerability was discovered, these AI agents were asked to revisit and review the bulletproof implementation specifically. And, again, they didn't find any problem with it.
 
-## Our assessment at the moment
+## Our Assessment
 
 The Beam developers consider that the probability of this vulnerability having been exploited is low.
 
@@ -50,14 +48,9 @@ Several aspects lead to this assessment:
 
 3. If done naively (for instance by asking an AI to create a working proof of concept, and then try using it) such an attack could leave a pattern that can be recognized. After the vulnerability was reported, the entire blockchain history was scanned, and no such pattern was identified.
 
-4. We are aware that there was a harsh Beam coin price decline recently. We analyzed the public trading data: trading volumes, possible price discrepancies between exchanges, unusual activities, etc. We believe there is no evidence that suggests a hidden inflation exploitation.
-   Prior to the price drop, the first anomaly we see is the sudden trade volume drop on MEXC (used to be the biggest exchange for Beam) on June 12th 2026. We don’t know the exact reason for this, probably a Market Maker was deactivated. Immediately after this, the Beam price started declining. Then, during the following days, there was a surge in the Beam trade volume on the NonKYC exchange. But this surge (1) albeit high for this exchange, still was much lower than normal daily volume on MEXC before the drop, (2) lasted for some period, then stopped on June 29th 2026.
-
-   If the Beam price decline would’ve been due to hidden inflation, we’d expect to see an overall increase in market volume, not decline. The spike in trading volume on NonKYC probably indicates big holders (whales) anonymously cashing-out.
-
 ## The next steps
 
-As said above, Beam developers consider at the moment that the probability of this vulnerability having been exploited is low. However, we cannot be 100% sure. There is objectively no guaranteed way -today- to ensure the exploit did not take place.
+As said above, Beam developers currently assess the likelihood of exploitation as low. However, due to Beam’s privacy-preserving design, additional verification is required to provide stronger assurance around supply integrity. This is why we are proposing a lustration process for community review.
 
 One considered option to confirm it didn’t, is the implementation of a "lustration" process, which would allow verifying the supply integrity at a given moment. Within this process, every unspent output of a past transaction (both Mimblewimble and Lelantus) would have to be disclosed upon its first use. Its amount and its asset type will be disclosed, but its owner would remain concealed. This disclosure would happen only once, and further transactions would then go back to the normal privacy of the Mimblewimble and Lelantus protocols.
 
@@ -70,5 +63,7 @@ If and when the community chooses to do this, an additional network upgrade will
 ## Conclusion
 
 The Beam developers would like to thank [MonclairTrades](https://x.com/MonclairTrades) for the responsible disclosure of this vulnerability.
+
+Most importantly, the vulnerability has now been patched, the network has upgraded, and the proposed next step is focused on giving the community an additional path to independently verify supply integrity.
 
 This discovery underscores the enduring value of careful cryptographic review, which allowed identifying such a subtle flaw that eluded multiple professional audits as well as state-of-the-art AI agents. The strength of Beam’s privacy guarantees depends on the robustness of its underlying cryptography, and that robustness is, in the end, upheld by the vigilance of the people who read and challenge the code.

--- a/middleware/trailing-slash.global.ts
+++ b/middleware/trailing-slash.global.ts
@@ -1,0 +1,20 @@
+export default defineNuxtRouteMiddleware((to) => {
+  // Canonical URLs have no trailing slash — every route is prerendered
+  // slash-less. Redirect e.g. /docs/ecosystem/ -> /docs/ecosystem so
+  // trailing-slash links, bookmarks, or crawlers don't land on an
+  // unprerendered route (which 404s on load, or on SPA navigation re-runs a
+  // client-side content query that boots the @nuxt/content SQLite-WASM engine).
+  // Done in middleware rather than public/_redirects because Cloudflare Pages
+  // requires splats at the end of a source path, so a single global
+  // trailing-slash rule (/*/ -> /:splat) isn't expressible there.
+  if (to.path.length > 1 && to.path.endsWith("/")) {
+    return navigateTo(
+      {
+        path: to.path.replace(/\/+$/, ""),
+        query: to.query,
+        hash: to.hash,
+      },
+      { redirectCode: 301 },
+    );
+  }
+});

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -184,6 +184,12 @@ export default defineNuxtConfig({
       routes: [...contentRoutes],
       crawlLinks: true,
       failOnError: false,
+      // Emit flat "foo.html" files instead of "foo/index.html". Cloudflare
+      // Pages then treats the no-trailing-slash URL as canonical (and 301s
+      // "/foo/" -> "/foo" at the edge), instead of canonicalizing to the
+      // trailing-slash form. That keeps the canonical URL aligned with the
+      // sitemap and the trailing-slash middleware — no redirect churn.
+      autoSubfolderIndex: false,
     },
   },
   hooks: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -146,16 +146,7 @@ export default defineNuxtConfig({
     "nuxt-security",
     "@nuxtjs/fontaine",
     "@nuxt/content",
-    "nuxt-multi-cache",
   ],
-  multiCache: {
-    component: {
-      // If true the cache is enabled.
-      // If false the cache is disabled, but the component is still added to
-      // the build.
-      enabled: true,
-    },
-  },
   security: {
     nonce: true,
     ssg: {
@@ -170,9 +161,14 @@ export default defineNuxtConfig({
           "'nonce-{{nonce}}'", // Nonce placeholders in the SSR case will allow inline scripts generated on the server
           // "'strict-dynamic'", // Use strict dynamic as outlined here: https://nuxt-security.vercel.app/documentation/advanced/strict-csp#strict-dynamic-csp-level-3
           "'self'", // Allow external scripts from self origin
-          "'wasm-unsafe-eval'", // Nuxt Content v3 compiles a client-side SQLite WASM module for queries
+          // No 'wasm-unsafe-eval': every @nuxt/content query is payload-served
+          // (all queryCollection calls run inside useAsyncData, and no page wraps
+          // its content component in <RenderCacheable>), so the client-side
+          // SQLite-WASM engine is never instantiated in the browser. Keep it that
+          // way — a client-only query (e.g. a live useSearchCollection) would
+          // reintroduce the WASM boot and require this directive again.
         ],
-        "worker-src": "'self' blob:",
+        "worker-src": "'self'",
         "frame-ancestors": false, // This one doesn't work when CSP is in Meta
       },
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "gsap": "^3.15.0",
     "markdown-it": "^14.2.0",
     "npm-check-updates": "^16.14.20",
-    "nuxt-multi-cache": "^3.4.0",
     "nuxt-security": "^1.4.3",
     "swiper": "^14.0.1",
     "tailwindcss": "^3.4.19",

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -15,7 +15,7 @@ const { data: posts } = await useAsyncData(
       .all(),
   {
     getCachedData: (key) =>
-      nuxtApp.isHydrating ? nuxtApp.payload.data[key] : undefined,
+      nuxtApp.payload.data[key] ?? nuxtApp.static.data[key],
   },
 );
 

--- a/pages/docs/[...slug].vue
+++ b/pages/docs/[...slug].vue
@@ -1,17 +1,32 @@
 <template>
-  <RenderCacheable :cache-key="[routeName, currentCategory].join('--')">
-    <DocsItem :route-name="routeName" :current-category="currentCategory" />
-  </RenderCacheable>
+  <DocsItem :route-name="routeName" :current-category="currentCategory" />
 </template>
 
 <script lang="ts" setup>
 const route = useRoute();
 
-// optimize page generation by caching content for each request
-// NOT compatible with multi-language (would need to also pass the lang to DocsItem but will require significant amount of RAM)
+// DocsItem is rendered directly (not wrapped in <RenderCacheable>). The cache
+// wrapper rendered DocsItem in an isolated SSR pass, so its inner useAsyncData
+// payloads were NOT serialized into the route's _payload.json — forcing every
+// docs query to re-run client-side and boot the @nuxt/content SQLite-WASM
+// engine on SPA navigation. Rendering DocsItem inline serializes those payloads
+// (same as blog's <BlogPost>), so the client never queries and never loads WASM.
 
-// use route.fullPath instead of route.params.slug
-const routeName = await handleIndex(normalizePath(route.fullPath));
+// `handleIndex` runs a content query (does a `<path>/readme` exist?), so it must
+// be payload-cached via useAsyncData — otherwise it re-executes client-side on
+// every docs navigation and boots the SQLite-WASM engine in the browser.
+//
+// The key MUST use the normalized path, not the raw route.fullPath: Nitro
+// prerenders "/docs/desktop/" (trailing slash) while an in-app link is
+// "/docs/desktop" (no slash). Keying on the raw path makes the two disagree, so
+// the client misses the payload, re-runs handleIndex (and its query), and boots
+// WASM. Normalizing first makes the prerender and client keys identical.
+const normalizedPath = normalizePath(route.fullPath);
+const { data: routeName } = await useAsyncData(
+  `docs-routename-${normalizedPath}`,
+  () => handleIndex(normalizedPath),
+  { default: () => normalizedPath },
+);
 const currentCategory = extractCategory(route.fullPath) as string;
 
 definePageMeta({

--- a/pages/docs/index.vue
+++ b/pages/docs/index.vue
@@ -14,6 +14,7 @@ const { data: pages } = await useAsyncData(
   async () => {
     const results = await queryCollection("docs")
       .where("title", "IS NOT NULL")
+      .select("path", "title", "description")
       .all();
     const seen = new Set<string>();
     return results.filter((p) => {
@@ -24,7 +25,7 @@ const { data: pages } = await useAsyncData(
   },
   {
     getCachedData: (key) =>
-      nuxtApp.isHydrating ? nuxtApp.payload.data[key] : undefined,
+      nuxtApp.payload.data[key] ?? nuxtApp.static.data[key],
   },
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5139,13 +5139,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tusbar/cache-control@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@tusbar/cache-control@npm:1.0.2"
-  checksum: e464b174fdc42aded3aae9ff4a4dc6963e3b1c861671cb6abf8f2558d5f00f2068280a1f9b10625987f2c8b13be6486f485e8322d95faa717be30ecb615fa878
-  languageName: node
-  linkType: hard
-
 "@tybys/wasm-util@npm:^0.10.2, @tybys/wasm-util@npm:^0.10.3":
   version: 0.10.3
   resolution: "@tybys/wasm-util@npm:0.10.3"
@@ -7065,7 +7058,6 @@ __metadata:
     node-html-parser: ^7.1.0
     npm-check-updates: ^16.14.20
     nuxt: ^3.21.8
-    nuxt-multi-cache: ^3.4.0
     nuxt-security: ^1.4.3
     nuxt-seo-utils: ^8.3.1
     prettier: ^3.9.4
@@ -14568,16 +14560,6 @@ __metadata:
   version: 1.0.0
   resolution: "nuxt-define@npm:1.0.0"
   checksum: fecda32862d77a90dc659e864597785a91a5a2e64de423aec1a2e1912bc2b0bf678d98f51fe3d740bcff2e83d20092439a436ae6ab6b8946dfa8cc20359ca578
-  languageName: node
-  linkType: hard
-
-"nuxt-multi-cache@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "nuxt-multi-cache@npm:3.4.0"
-  dependencies:
-    "@nuxt/kit": ^3.13.2
-    "@tusbar/cache-control": ^1.0.2
-  checksum: d751de4fcae727056fd5bfc69001fcf83f0b1f5763c9dcb8c5db6b1bc0f7ac26e2aa003ec11604396569887eb443ab1117389b40a2402656964102e8287e8b01
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Reduces the website's client-side runtime memory, fixes the docs link/route bugs that surfaced from it, plus a small unrelated content edit.

The headline change: `@nuxt/content` boots an ~856KB SQLite-WASM engine (plus the compressed collection dump and a worker) in the browser whenever a `queryCollection` runs client-side. On this fully-prerendered SSG site (deployed to Cloudflare Pages) every result is already in the payload, so this routes **all** content queries through `useAsyncData` and serves them from the payload — the client SQLite-WASM engine now never fetches or instantiates. With no client query left, the CSP drops `'wasm-unsafe-eval'` and tightens `worker-src` to `'self'`.

## Commits

- **`fix(client)`** — tear down eventBus/DOM listeners, a gsap tween, and a hover timeout on unmount (they accumulated across in-app navigation); pause the hero background timeline when it scrolls off-screen so GSAP stops driving frames.
- **`perf(content)`** — payload-serve all docs/blog queries: fix the `getCachedData` gate that re-ran on SPA nav, wrap the bare docs queries, render `DocsItem` directly instead of inside `<RenderCacheable>` (which stopped its payloads from serializing), and key the docs route on the **normalized** path so prerender and client agree (a trailing-slash mismatch was re-running `handleIndex`). Drop `'wasm-unsafe-eval'` from the CSP.
- **`chore(deps)`** — remove `nuxt-multi-cache` (its only consumer, `<RenderCacheable>`, is gone).
- **`content`** — revise the hardfork-six blog post and fix its frontmatter (unrelated to the above).
- **`fix(docs)`** — resolve GitBook `./#anchor` content links to same-page anchors. They were joined onto the current path as `/docs/<cat>/./#anchor`, which normalizes to a trailing-slash route that isn't prerendered (blank page + CSP-blocked WASM on click, 404 on reload).
- **`fix(routing)`** — global middleware that 301-redirects any trailing-slash URL to its no-slash canonical (bookmarks / manual entry / external links). Preserves query + hash; applies to i18n-prefixed routes too.
- **`chore(build)`** — prerender flat `foo.html` files (`nitro.prerender.autoSubfolderIndex: false`) instead of `foo/index.html`, so Cloudflare Pages treats the **no-slash URL as canonical** and 308-redirects `/foo/` and `/foo.html` to it at the edge — instead of *adding* a trailing slash and fighting the middleware.

## Why the trailing-slash fixes

Removing the WASM allowance *exposed* a latent bug: docs pages reached via a trailing-slash URL aren't prerendered, so they 404 on reload and, on SPA nav, re-ran a client-side query that the WASM engine used to silently absorb. `fix(docs)` stops the site from generating those URLs; `fix(routing)` rescues any reached directly; `chore(build)` aligns Cloudflare's own canonicalization with the no-slash form so there's no redirect churn (`.html` never appears in the browser URL — it's only the on-disk filename).

## Verification

- Full `yarn generate` (~3900 routes, 9 locales) succeeds; build heap stays under the existing 8 GB ceiling.
- Chrome DevTools against the static build:
  - Docs (index → category → child doc) and blog SPA navigation render with **zero** `sqlite3.wasm` / `sql_dump.txt` / `__nuxt_content` requests and a clean console — verified with `'wasm-unsafe-eval'` removed.
  - Clicking the previously-broken `./#anchor` links stays on the current route and scrolls to the anchor.
  - `/docs/ecosystem/` and `/fr/docs/desktop/` (i18n) both redirect to the no-slash canonical, render, and load no WASM. Homepage and locale detection unaffected.
- Regression checks pass: docs/blog/changelog/atomic-swaps → 200, unknown docs path → 404, changelog DESC ordering intact.
- On the live Cloudflare Pages preview (fresh cache): `/docs/ecosystem` loads with **0 redirects** at the clean no-slash URL; `/docs/ecosystem/`, `/docs/ecosystem.html`, and `/docs/cli/` all 30x-redirect to the canonical no-slash form; no WASM anywhere.

## Notes

- Fixes a latent i18n bug as a side effect: the old `<RenderCacheable>` cache key omitted the locale, so translated UI chrome could leak across languages.
- The `~856KB` wasm + dump files are still emitted to `.output/public` as dead weight (never fetched at runtime). Stripping them post-build is possible but left out — it's a fragile guardrail that breaks silently if any future route queries content client-side.

Please review — **not for merge yet.**
