### PR TITLE
fix(blog): render locale-prefixed posts that aren't translated

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -161,14 +161,23 @@ export default defineNuxtConfig({
           "'nonce-{{nonce}}'", // Nonce placeholders in the SSR case will allow inline scripts generated on the server
           // "'strict-dynamic'", // Use strict dynamic as outlined here: https://nuxt-security.vercel.app/documentation/advanced/strict-csp#strict-dynamic-csp-level-3
           "'self'", // Allow external scripts from self origin
-          // No 'wasm-unsafe-eval': every @nuxt/content query is payload-served
-          // (all queryCollection calls run inside useAsyncData, and no page wraps
-          // its content component in <RenderCacheable>), so the client-side
-          // SQLite-WASM engine is never instantiated in the browser. Keep it that
-          // way — a client-only query (e.g. a live useSearchCollection) would
-          // reintroduce the WASM boot and require this directive again.
+          // Production omits 'wasm-unsafe-eval': in the static build every
+          // @nuxt/content query is payload-served (all queryCollection calls run
+          // inside useAsyncData, and no page wraps its content component in
+          // <RenderCacheable>), so the client-side SQLite-WASM engine is never
+          // instantiated. Keep it that way — a client-only query (e.g. a live
+          // useSearchCollection) would reintroduce the WASM boot in production.
+          //
+          // Dev has no prerendered _payload.json, so client-side navigation runs
+          // content queries against the SQLite-WASM engine and needs this
+          // directive; scope it to development only (like the connect-src ws
+          // above) so it never loosens the production CSP.
+          ...(process.env.NODE_ENV === "development"
+            ? ["'wasm-unsafe-eval'"]
+            : []),
         ],
-        "worker-src": "'self'",
+        "worker-src":
+          process.env.NODE_ENV === "development" ? "'self' blob:" : "'self'",
         "frame-ancestors": false, // This one doesn't work when CSP is in Meta
       },
     },

--- a/pages/blog/[...slug].vue
+++ b/pages/blog/[...slug].vue
@@ -5,11 +5,15 @@
 <script lang="ts" setup>
 const route = useRoute();
 
-// Handle the route path for the blog post
-const routeName = computed(() => {
-  const path = route.path.replace(/^\/blog\//, "").replace(/\/$/, "");
-  return `/blog/${path}`;
-});
+// Strip any i18n locale prefix (/de/blog/... -> /blog/...) and trailing slash so
+// the content query always targets the canonical English post path. Blog posts
+// aren't translated; a localized URL renders the same content with translated
+// chrome (same as docs). Without normalizing, a locale-prefixed path produced a
+// broken query path (/blog//de/blog/...) and threw a 404 — so the route failed
+// to prerender (404 on reload) and failed on SPA navigation from a localized
+// blog index. normalizePath keys prerender and client identically, matching the
+// docs page.
+const routeName = computed(() => normalizePath(route.path));
 
 definePageMeta({
   layout: "default",


### PR DESCRIPTION
## Summary

Opening a blog post under a non-English locale prefix — e.g. `https://beam.mw/de/blog/news/hardfork-six` — failed to load and 404'd on reload, even though blog posts aren't translated (they should render the English content with translated chrome, like docs do).

## Root cause

`pages/blog/[...slug].vue` built the content-query path by stripping only a leading `/blog/`:

```js
route.path.replace(/^\/blog\//, "").replace(/\/$/, "")
```

For a locale-prefixed URL like `/de/blog/news/hardfork-six` that regex doesn't match, producing the broken query path `/blog//de/blog/news/hardfork-six`. `queryCollection("blog").path(...)` returns null → `createError(404)`. That single throw caused **both** symptoms:

- **Doesn't load** on SPA nav from a localized blog index (render throws).
- **404 on reload** — the same throw during the prerender crawl meant the route was never emitted.

The docs page never had this because it already normalizes the path with `normalizePath()`.

## Fix

- **`pages/blog/[...slug].vue`** — use `normalizePath(route.path)` (same helper the docs page uses) so a localized URL queries the canonical English post and the prerender/client `useAsyncData` keys agree.
- **`nuxt.config.ts`** — scope the `'wasm-unsafe-eval'` / `blob:` worker CSP allowance to **development only**. Dev has no prerendered `_payload.json`, so client-side content navigation must query via the SQLite-WASM engine; production stays payload-served under the tightened CSP from #373.

## Verification

- Full `yarn generate`: all 9 locales now emit `blog/news/hardfork-six.html` (previously English-only; the `de/blog/` folder had zero posts). German post renders real content (English body + German chrome), and its payload keys match the English ones exactly, so the client never boots WASM.
- `yarn dev`: client-side navigation to a localized blog post works again (WASM query permitted in dev only).